### PR TITLE
form boolean values no longer being saved as strings

### DIFF
--- a/src/components/pages/CreateNewTrash/CreateNewTrash.js
+++ b/src/components/pages/CreateNewTrash/CreateNewTrash.js
@@ -32,11 +32,11 @@ class CreateNewTrash extends React.Component {
 
   recyclabaleChange = (e) => {
     console.error('recyclable change func just fired');
-    this.setState({ isRecyclable: e.target.value });
+    this.setState({ isRecyclable: e.target.checked });
   }
 
   didYouRecycleChange = (e) => {
-    this.setState({ didYouRecycle: e.target.value });
+    this.setState({ didYouRecycle: e.target.checked });
   }
 
   saveNewTrash = (e) => {

--- a/src/components/pages/EditTrash/EditTrash.js
+++ b/src/components/pages/EditTrash/EditTrash.js
@@ -47,11 +47,11 @@ class EditTrash extends React.Component {
   }
 
   recyclabaleChange = (e) => {
-    this.setState({ isRecyclable: e.target.value });
+    this.setState({ isRecyclable: e.target.checked });
   }
 
   didYouRecycleChange = (e) => {
-    this.setState({ didYouRecycle: e.target.value });
+    this.setState({ didYouRecycle: e.target.checked });
   }
 
   updateTrash = (e) => {


### PR DESCRIPTION
Fixed problem with the create and edit forms sending booleans to Firebase as strings by changing e.target.value to e.target.checked 